### PR TITLE
docs: add swagger docs for one-on-one chat apis

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -55,7 +55,49 @@ app.use('/api/v1/users', userRouter);
 app.use('/api/v1/friend-requests', friendRequestsRouter);
 
 // One on one chat routes
-app.use('/api/v1/chats/one-on-one', oneOnOneChatRouter);
+app.use(
+  '/api/v1/chats/one-on-one',
+  oneOnOneChatRouter
+  /* 
+  #swagger.tags = ['One-On-One Chats']
+
+  #swagger.security = [{
+   "bearerAuth": []
+  }] 
+
+  #swagger.responses[401] = {
+    description: "Unauthorized Access",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/UnauthorizedAccessResponse"
+        },
+        examples: {
+          unauthorizedAccessResponse: {
+            $ref: "#/components/examples/UnauthorizedAccessResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[500] = {
+    description: 'Internal server error',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/InternalServerErrorResponse"
+        },
+        examples: {
+          internalServerErrorResponse: {
+            $ref: "#/components/examples/InternalServerErrorResponse"
+          }
+        }
+      }           
+    }
+  } 
+*/
+);
 
 // Group Chat Routes
 app.use('/api/v1/chats/group', groupChatRouter);

--- a/src/docs/errors/examples.ts
+++ b/src/docs/errors/examples.ts
@@ -19,5 +19,26 @@ export const errorExamples = {
       message: 'Unauthorized access',
       data: null
     }
+  },
+  NotFoundResponse: {
+    value: {
+      success: false,
+      message: 'Not Found',
+      data: null
+    }
+  },
+  ForbiddenResponse: {
+    value: {
+      success: false,
+      message: 'Forbidden',
+      data: null
+    }
+  },
+  ConflictResponse: {
+    value: {
+      success: false,
+      message: 'Conflict',
+      data: null
+    }
   }
 };

--- a/src/docs/errors/schemas.ts
+++ b/src/docs/errors/schemas.ts
@@ -22,5 +22,29 @@ export const errorSchemas = {
       message: { type: 'string' },
       data: { type: 'object', nullable: true }
     }
-  }
+  },
+  ForbiddenResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: { type: 'object', nullable: true }
+    }
+  },
+  NotFoundResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: { type: 'object', nullable: true }
+    }
+  },
+  ConflictResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: { type: 'object', nullable: true }
+    }
+  },
 };

--- a/src/docs/index.ts
+++ b/src/docs/index.ts
@@ -1,7 +1,8 @@
 import { authExamples, authSchemas } from './auth';
 import { errorExamples, errorSchemas } from './errors';
+import { oneOnOneChatExamples, oneOnOneChatSchemas } from './one-on-one-chats';
 
-const swaggerSchemas = { ...authSchemas, ...errorSchemas };
-const swaggerExamples = { ...authExamples, ...errorExamples };
+const swaggerSchemas = { ...authSchemas, ...errorSchemas, ...oneOnOneChatSchemas };
+const swaggerExamples = { ...authExamples, ...errorExamples, ...oneOnOneChatExamples };
 
 export { swaggerSchemas, swaggerExamples };

--- a/src/docs/one-on-one-chats/examples.ts
+++ b/src/docs/one-on-one-chats/examples.ts
@@ -1,0 +1,88 @@
+export const oneOnOneChatExamples = {
+  CreateOneOnOneChatResponse: {
+    value: {
+      success: true,
+      message: 'Chat created successfully!',
+      data: {
+        id: '67162056177977602501d7d6',
+        initiatorId: '66b30bbeaea1612592e8609b',
+        participantId: '66c58d3c09c4603fe4b47527',
+        vanishMode: false,
+        createdAt: '2024-10-21T09:35:18.596Z',
+        updatedAt: '2024-10-21T09:35:18.596Z',
+        lastMessageAt: '2024-10-21T09:35:18.596Z',
+        deletedForInitiator: null,
+        deletedForParticipant: null
+      }
+    }
+  },
+  GetOneOnOneChatDetailsResponse: {
+    value: {
+      success: true,
+      message: 'Chat details retrieved successfully!',
+      data: {
+        id: '67162056177977602501d7d6',
+        initiatorId: '66b30bbeaea1612592e8609b',
+        participantId: '66c58d3c09c4603fe4b47527',
+        vanishMode: false,
+        createdAt: '2024-10-21T09:35:18.596Z',
+        updatedAt: '2024-10-21T09:35:18.596Z',
+        lastMessageAt: '2024-10-21T09:35:18.596Z',
+        deletedForInitiator: null,
+        deletedForParticipant: null
+      }
+    }
+  },
+  UpdateOneOnOneChatSettingsResponse: {
+    value: {
+      success: true,
+      message: 'Chat settings updated successfully!',
+      data: null
+    }
+  },
+  GetOneOnOneChatMessagesResponse: {
+    value: {
+      success: true,
+      message: 'Chat messages retrieved successfully!',
+      data: {
+        messages: [
+          {
+            id: '66f3f8b0e493af07d1fe4537',
+            content: 'Hi there!',
+            senderId: '66b33a2d19b3564668300673',
+            oneOnOneChatId: '66d6cd74e5cb752390d88fab',
+            groupChatId: null,
+            createdAt: '2024-09-25T11:49:04.375Z',
+            updatedAt: '2024-09-25T11:55:18.398Z',
+            isDeleted: false
+          },
+          {
+            id: '66f3f4523f136de60dd42f5a',
+            content: 'Hello!',
+            senderId: '66b33a2d19b3564668300673',
+            oneOnOneChatId: '66d6cd74e5cb752390d88fab',
+            groupChatId: null,
+            createdAt: '2024-09-25T11:30:26.503Z',
+            updatedAt: '2024-09-25T11:55:56.196Z',
+            isDeleted: false
+          },
+          {
+            id: '66d6ce4ae5cb752390d88fac',
+            content: 'How are you?',
+            senderId: '66b33a2d19b3564668300673',
+            oneOnOneChatId: '66d6cd74e5cb752390d88fab',
+            groupChatId: null,
+            createdAt: '2024-09-03T08:52:26.926Z',
+            updatedAt: '2024-09-03T08:52:26.926Z',
+            isDeleted: false
+          }
+        ],
+        pagination: {
+          totalCount: 3,
+          hasNextPage: false,
+          nextCursor: null
+        }
+      }
+    }
+  }
+};

--- a/src/docs/one-on-one-chats/index.ts
+++ b/src/docs/one-on-one-chats/index.ts
@@ -1,0 +1,2 @@
+export { oneOnOneChatExamples } from './examples';
+export { oneOnOneChatSchemas } from './schemas';

--- a/src/docs/one-on-one-chats/schemas.ts
+++ b/src/docs/one-on-one-chats/schemas.ts
@@ -1,0 +1,114 @@
+export const oneOnOneChatSchemas = {
+  CreateOneOnOneChatRequest: {
+    type: 'object',
+    properties: {
+      initiatorId: {
+        type: 'string',
+        description: "Initiator's ID",
+        example: ''
+      },
+      participantId: {
+        type: 'string',
+        description: "Participant's ID",
+        example: ''
+      }
+    }
+  },
+  CreateOneOnOneChatResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          initiatorId: { type: 'string' },
+          participantId: { type: 'string' },
+          vanishMode: { type: 'boolean' },
+          createdAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: 'string', format: 'date-time' },
+          lastMessageAt: { type: 'string', format: 'date-time' },
+          deletedForInitiator: { type: 'boolean', nullable: true },
+          deletedForParticipant: { type: 'object', nullable: true }
+        }
+      }
+    }
+  },
+  GetOneOnOneChatDetailsResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          initiatorId: { type: 'string' },
+          participantId: { type: 'string' },
+          vanishMode: { type: 'boolean' },
+          createdAt: { type: 'string', format: 'date-time' },
+          updatedAt: { type: 'string', format: 'date-time' },
+          lastMessageAt: { type: 'string', format: 'date-time' },
+          deletedForInitiator: { type: 'boolean', nullable: true },
+          deletedForParticipant: { type: 'boolean', nullable: true }
+        }
+      }
+    }
+  },
+  UpdateOneOnOneChatSettingsRequest: {
+    type: 'object',
+    properties: {
+      settings: {
+        type: 'object',
+        properties: {
+          vanishMode: { type: 'boolean', nullable: true, example: false }
+        }
+      }
+    }
+  },
+  UpdateOneOnOneChatSettingsResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: { type: 'object', nullable: true }
+    }
+  },
+  GetOneOnOneChatMessagesResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: {
+        type: 'object',
+        properties: {
+          messages: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                content: { type: 'string' },
+                senderId: { type: 'string' },
+                oneOnOnechatId: { type: 'string' },
+                groupChatId: { type: 'string' },
+                createdAt: { type: 'string', format: 'date-time' },
+                updatedAt: { type: 'string', format: 'date-time' },
+                isDeleted: { type: 'boolean' }
+              }
+            }
+          },
+          pagination: {
+            type: 'object',
+            properties: {
+              totalCount: { type: 'number' },
+              hasNextPage: { type: 'boolean' },
+              nextCursor: { type: 'string', nullable: true }
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/src/routes/one-on-one-chats.routes.ts
+++ b/src/routes/one-on-one-chats.routes.ts
@@ -20,17 +20,345 @@ oneOnOneChatRouter.post(
   validateRequest(createOneOnOneChatSchema),
   verifyToken('accessToken'),
   createOneOnOneChat
+  /* 
+  #swagger.summary = 'Create a new one-on-one chat'
+
+  #swagger.description = 
+  'Initiates a secure, direct conversation between two users who are confirmed friends. 
+  This endpoint verifies the friendship status, prevents duplicate chats, and establishes 
+  a private space for personal communication.'
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'application/json': {
+        schema:{
+          $ref: '#/components/schemas/CreateOneOnOneChatRequest'
+        }
+      }
+    }
+  } 
+
+  #swagger.responses[201] = {
+    description: 'Chat created successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/CreateOneOnOneChatResponse'
+        },
+        examples: {
+          chatCreationResponse: {
+            $ref: "#/components/examples/CreateOneOnOneChatResponse"
+          }
+        }
+      }
+    }
+  }
+    
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+
+  #swagger.responses[409] = {
+    description: 'Conflict',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ConflictResponse"
+        },
+        examples: {
+          conflictResponse: {
+            $ref: "#/components/examples/ConflictResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
 );
 
-oneOnOneChatRouter.get('/:chatId', verifyToken('accessToken'), getOneOnOneChatDetails);
+oneOnOneChatRouter.get(
+  '/:chatId',
+  verifyToken('accessToken'),
+  getOneOnOneChatDetails
+  /* 
+  #swagger.summary = 'Get details of an existing one-on-one chat'
+
+  #swagger.description = 
+  'Fetches detailed information about an existing one-on-one chat, including participant details, 
+  chat settings, and metadata. 
+  This endpoint provides a complete overview of the chat's current state and configuration.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'one-on-one chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.responses[200] = {
+    description: 'Chat details retrieved successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/GetOneOnOneChatDetailsResponse'
+        },
+        examples: {
+          chatCreationResponse: {
+            $ref: "#/components/examples/GetOneOnOneChatDetailsResponse"
+          }
+        }
+      }
+    }
+  }
+
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+
+  #swagger.responses[409] = {
+    description: 'Conflict',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ConflictResponse"
+        },
+        examples: {
+          conflictResponse: {
+            $ref: "#/components/examples/ConflictResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
+);
 
 oneOnOneChatRouter.patch(
   '/:chatId/settings',
   validateRequest(updateOneOnOneChatSettingsSchema),
   verifyToken('accessToken'),
   updateOneOnOneChatSettings
+  /* 
+  #swagger.summary = 'Update settings of an existing one-on-one chat'
+
+  #swagger.description = 
+  'Modifies the settings of an existing one-on-one chat. This endpoint allows users to toggle  
+  the vanish mode on or off for v1, enhancing privacy options for sensitive conversations.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'one-on-one chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'application/json': {
+        schema:{
+          $ref: '#/components/schemas/UpdateOneOnOneChatSettingsRequest'
+        }
+      }
+    }
+  }   
+
+  #swagger.responses[200] = {
+    description: 'Chat settings updated successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/UpdateOneOnOneChatSettingsResponse'
+        },
+        examples: {
+          chatUpdationResponse: {
+            $ref: "#/components/examples/UpdateOneOnOneChatSettingsResponse"
+          }
+        }
+      }
+    }
+  }
+    
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  } 
+    
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
 );
 
-oneOnOneChatRouter.get('/:chatId/messages', verifyToken('accessToken'), getOneOnOneChatMessages);
+oneOnOneChatRouter.get(
+  '/:chatId/messages',
+  verifyToken('accessToken'),
+  getOneOnOneChatMessages
+  /* 
+  #swagger.summary = 'Retrieve messages from a specific one-on-one chat'
+
+  #swagger.description = 
+  'Fetches the message history of an existing one-on-one chat. 
+  This endpoint allows users to access the conversation content, including text messages, 
+  timestamps, and any associated metadata. 
+  It supports pagination for efficient retrieval of large message histories.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'one-on-one chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.parameters['cursor'] = {
+    in: 'query',                            
+    description: 'Pagination cursor for fetching the next set of results',                   
+    required: false,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.parameters['search'] = {
+    in: 'query',                            
+    description: 'Search term to filter messages by content',                   
+    required: false,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.parameters['take'] = {
+    in: 'query',                            
+    description: 'Number of messages to retrieve per request',                   
+    required: false,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.responses[200] = {
+    description: 'Chat messages retrieved successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/GetOneOnOneChatMessagesResponse'
+        },
+        examples: {
+          getMessagesResponse: {
+            $ref: "#/components/examples/GetOneOnOneChatMessagesResponse"
+          }
+        }
+      }
+    }
+  }
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  } 
+    
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
+);
 
 export default oneOnOneChatRouter;


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the One-On-One Chat APIs. It includes detailed Swagger annotations for all endpoints related to private messaging, covering chat creation, message retrieval, and settings management. The documentation provides clear summaries, request/response schemas, and example payloads to facilitate easier integration and understanding of these critical communication features.