### PR TITLE
docs: sm-117 - add swagger docs for group chat apis

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -216,7 +216,49 @@ app.use(
 );
 
 // Group Chat Routes
-app.use('/api/v1/chats/group', groupChatRouter);
+app.use(
+  '/api/v1/chats/group',
+  groupChatRouter
+  /* 
+  #swagger.tags = ['Group Chats']
+
+  #swagger.security = [{
+   "bearerAuth": []
+  }] 
+
+  #swagger.responses[401] = {
+    description: "Unauthorized Access",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/UnauthorizedAccessResponse"
+        },
+        examples: {
+          unauthorizedAccessResponse: {
+            $ref: "#/components/examples/UnauthorizedAccessResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[500] = {
+    description: 'Internal server error',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/InternalServerErrorResponse"
+        },
+        examples: {
+          internalServerErrorResponse: {
+            $ref: "#/components/examples/InternalServerErrorResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
+);
 
 // Message Routes
 app.use('/api/v1/messages', messagesRouter);

--- a/src/docs/group-chats/examples.ts
+++ b/src/docs/group-chats/examples.ts
@@ -1,0 +1,102 @@
+export const groupChatExamples = {
+  CreateGroupChatResponse: {
+    success: true,
+    message: 'Group chat created successfully!',
+    data: {
+      id: '671764c1c24a444d00123456',
+      name: 'New Group Chat',
+      ownerId: '66b33a2d19b3564668356789',
+      groupDescription: 'Welcome to our new group chat!',
+      groupIcon:
+        'https://res.cloudinary.com/du9x9e2oh/image/upload/v1729586123/group_icons/mkymgovdvgfv8ls2.jpg',
+      createdAt: '2024-10-22T08:39:29.733Z',
+      updatedAt: '2024-10-22T08:39:29.733Z',
+      lastMessageAt: '2024-10-22T08:39:29.733Z',
+      memberIds: ['66b30bbeaea1612592e7501a', '671764c1c24a444d00123456']
+    }
+  },
+  GetGroupChatDetailsResponse: {
+    success: true,
+    message: 'Chat details retrieved successfully!',
+    data: {
+      id: '671764c1c24a444d00123456',
+      name: 'New Group Chat',
+      ownerId: '66b33a2d19b3564668356789',
+      groupDescription: 'Welcome to our new group chat!',
+      groupIcon:
+        'https://res.cloudinary.com/du9x9e2oh/image/upload/v1729586123/group_icons/mkymgovdvgfv8ls2.jpg',
+      createdAt: '2024-10-22T08:39:29.733Z',
+      updatedAt: '2024-10-22T08:39:29.733Z',
+      lastMessageAt: '2024-10-22T08:39:29.733Z',
+      memberIds: ['66b30bbeaea1612592e7501a', '671764c1c24a444d00123456']
+    }
+  },
+  UpdateGroupChatSettingsResponse: {
+    success: true,
+    message: 'Chat settings updated successfully!',
+    data: null
+  },
+  GetGroupChatMessagesResponse: {
+    success: true,
+    message: 'Chat messages retrieved successfully!',
+    data: {
+      messages: [
+        {
+          id: '66f3ec5c0390fdcf34ce778d',
+          content: 'New Message 4',
+          senderId: '66b33a2d19b3564668398765',
+          oneOnOneChatId: null,
+          groupChatId: '66f15453eda9647f5be80ab7',
+          createdAt: '2024-09-25T10:56:28.374Z',
+          updatedAt: '2024-09-25T10:56:28.374Z',
+          isDeleted: false
+        },
+        {
+          id: '66f3e78489bb1b6a4f79cf7c',
+          content: 'New Message 3',
+          senderId: '66b33a2d19b3564668356789',
+          oneOnOneChatId: null,
+          groupChatId: '66f15453eda9647f5be80ab7',
+          createdAt: '2024-09-25T10:35:48.140Z',
+          updatedAt: '2024-09-25T10:35:48.140Z',
+          isDeleted: false
+        },
+        {
+          id: '66f3e5f689bb1b6a4f79cf7b',
+          content: 'New Message 2',
+          senderId: '66b33a2d19b3564668398765',
+          oneOnOneChatId: null,
+          groupChatId: '66f15453eda9647f5be80ab7',
+          createdAt: '2024-09-25T10:29:10.240Z',
+          updatedAt: '2024-09-25T10:29:10.240Z',
+          isDeleted: false
+        },
+        {
+          id: '66f3d4aee4e5768ce4fc250a',
+          content: 'New Message 1',
+          senderId: '66b33a2d19b3564668356789',
+          oneOnOneChatId: null,
+          groupChatId: '66f15453eda9647f5be80ab7',
+          createdAt: '2024-09-25T09:15:26.451Z',
+          updatedAt: '2024-09-25T09:15:26.451Z',
+          isDeleted: false
+        }
+      ],
+      pagination: {
+        totalCount: 4,
+        hasNextPage: false,
+        nextCursor: null
+      }
+    }
+  },
+  AddMembersToGroupChatResponse: {
+    success: true,
+    message: 'Members added successfully!',
+    data: null
+  },
+  RemoveMemberFromGroupChatResponse: {
+    success: true,
+    message: 'Member removed successfully!',
+    data: null
+  }
+};

--- a/src/docs/group-chats/index.ts
+++ b/src/docs/group-chats/index.ts
@@ -1,0 +1,2 @@
+export { groupChatExamples } from './examples';
+export { groupChatSchemas } from './schemas';

--- a/src/docs/group-chats/schemas.ts
+++ b/src/docs/group-chats/schemas.ts
@@ -1,0 +1,145 @@
+const ResponseWithoutData = {
+  type: 'object',
+  properties: {
+    success: { type: 'boolean' },
+    message: { type: 'string' },
+    data: { type: 'object', nullable: 'true' }
+  }
+};
+
+const GroupChatResponseData = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    ownerId: { type: 'string' },
+    groupDescription: { type: 'string' },
+    groupIcon: { type: 'string' },
+    createdAt: { type: 'string', format: 'date-time' },
+    updatedAt: { type: 'string', format: 'date-time' },
+    lastMessageAt: { type: 'string', format: 'date-time' },
+    memberIds: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  }
+};
+
+const MessagesArray = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      content: { type: 'string' },
+      senderId: { type: 'string' },
+      oneOnOnechatId: { type: 'string' },
+      groupChatId: { type: 'string' },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+      isDeleted: { type: 'boolean' }
+    }
+  }
+};
+
+const Pagination = {
+  type: 'object',
+  properties: {
+    totalCount: { type: 'number' },
+    hasNextPage: { type: 'boolean' },
+    nextCursor: { type: 'string', nullable: true }
+  }
+};
+
+const MemberIdsArray = {
+  type: 'array',
+  items: {
+    type: 'string'
+  },
+  description: 'IDs of the group chat members',
+  example: ['']
+};
+
+export const groupChatSchemas = {
+  CreateGroupChatRequest: {
+    type: 'object',
+    properties: {
+      ownerId: { type: 'string', description: 'ID of the group chat creator/owner', example: '' },
+      memberIds: MemberIdsArray,
+      name: { type: 'string', description: 'Name of the group chat', example: '' },
+      groupDescription: {
+        type: 'string',
+        description: 'Description of the group chat',
+        example: ''
+      },
+      groupIcon: {
+        type: 'string',
+        description: 'Icon of the group chat',
+        format: 'binary'
+      }
+    },
+    required: ['ownerId', 'memberIds', 'name', 'groupIcon']
+  },
+  CreateGroupChatResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: GroupChatResponseData
+    }
+  },
+  GetGroupChatDetailsResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: GroupChatResponseData
+    }
+  },
+  UpdateGroupChatSettingsRequest: {
+    type: 'object',
+    properties: {
+      settings: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', example: '' },
+          groupDescription: { type: 'string', example: '' }
+        }
+      },
+      groupIcon: { type: 'string', format: 'binary' }
+    }
+  },
+  UpdateGroupChatSettingsResponse: ResponseWithoutData,
+  GetGroupChatMessagesResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: {
+        type: 'object',
+        properties: {
+          messages: MessagesArray,
+          pagination: Pagination
+        }
+      }
+    }
+  },
+  AddMembersToGroupChatRequest: {
+    type: 'object',
+    properties: {
+      ownerId: { type: 'string', description: 'ID of the group chat creator/owner', example: '' },
+      memberIds: MemberIdsArray
+    }
+  },
+  AddMembersToGroupChatResponse: ResponseWithoutData,
+  RemoveMemberFromGroupChatRequest: {
+    type: 'object',
+    properties: {
+      ownerId: { type: 'string', description: 'ID of the group chat creator/owner', example: '' },
+      memberId: { type: 'string', description: 'ID of the member to be deleted', example: '' }
+    }
+  },
+  RemoveMemberFromGroupChatResponse: ResponseWithoutData
+};

--- a/src/docs/index.ts
+++ b/src/docs/index.ts
@@ -1,6 +1,7 @@
 import { authExamples, authSchemas } from './auth';
 import { errorExamples, errorSchemas } from './errors';
 import { friendRequestExamples, friendRequestsSchemas } from './friend-requests';
+import { groupChatExamples, groupChatSchemas } from './group-chats';
 import { oneOnOneChatExamples, oneOnOneChatSchemas } from './one-on-one-chats';
 import { userExamples, userSchemas } from './users';
 
@@ -8,6 +9,7 @@ const swaggerSchemas = {
   ...authSchemas,
   ...errorSchemas,
   ...friendRequestsSchemas,
+  ...groupChatSchemas,
   ...oneOnOneChatSchemas,
   ...userSchemas
 };
@@ -15,6 +17,7 @@ const swaggerExamples = {
   ...authExamples,
   ...errorExamples,
   ...friendRequestExamples,
+  ...groupChatExamples,
   ...oneOnOneChatExamples,
   ...userExamples
 };

--- a/src/routes/group-chats.routes.ts
+++ b/src/routes/group-chats.routes.ts
@@ -26,9 +26,135 @@ groupChatRouter.post(
   upload.single('groupIcon'),
   validateRequest(createGroupChatSchema),
   createGroupChat
+  /*
+  #swagger.summary = 'Create a new group chat'
+
+  #swagger.description = 'Creates a group chat with specified members, customizable name, description, 
+  and group icon. The creator must be friends with all added members, and a group icon is mandatory. 
+  The creator automatically becomes the group owner with administrative privileges.'
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'multipart/form-data': {
+        schema:{
+          $ref: '#/components/schemas/CreateGroupChatRequest'
+        }
+      }
+    }
+  } 
+
+  #swagger.responses[201] = {
+    description: 'Chat created successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/CreateGroupChatResponse'
+        },
+        examples: {
+          chatCreationResponse: {
+            $ref: "#/components/examples/CreateGroupChatResponse"
+          }
+        }
+      }
+    }
+  }
+    
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
 );
 
-groupChatRouter.get('/:chatId', verifyToken('accessToken'), getGroupChatDetails);
+groupChatRouter.get(
+  '/:chatId',
+  verifyToken('accessToken'),
+  getGroupChatDetails
+  /*
+  #swagger.summary = 'Get details of a specific group chat'
+
+  #swagger.description = 'Fetches comprehensive details of a specific group chat, 
+  including name, description, icon, owner, and member information. 
+  Only group members and the owner can access these details. 
+  The response includes all current group settings and participant information.'
+
+  #swagger.responses[200] = {
+    description: 'Chat details retrieved successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/GetGroupChatDetailsResponse'
+        },
+        examples: {
+          chatDetailsResponse: {
+            $ref: "#/components/examples/GetGroupChatDetailsResponse"
+          }
+        }
+      }
+    }
+  }
+   
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
+);
 
 groupChatRouter.patch(
   '/:chatId/settings',
@@ -36,15 +162,287 @@ groupChatRouter.patch(
   upload.single('groupIcon'),
   validateRequest(updateGroupChatSettingsSchema),
   updateGroupChatSettings
+  /* 
+  #swagger.summary = 'Update settings of an existing group chat'
+
+  #swagger.description = 
+  'Enables group owners to modify chat settings including name, description, and group icon. 
+  The endpoint accepts settings in JSON format and supports image uploads for the group icon. 
+  Only the group owner has permission to update these settings.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'group chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'multipart/form-data': {
+        schema:{
+          $ref: '#/components/schemas/UpdateGroupChatSettingsRequest'
+        }
+      }
+    }
+  }   
+
+  #swagger.responses[200] = {
+    description: 'Chat settings updated successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/UpdateGroupChatSettingsResponse'
+        },
+        examples: {
+          chatSettingsUpdationResponse: {
+            $ref: "#/components/examples/UpdateGroupChatSettingsResponse"
+          }
+        }
+      }
+    }
+  }
+    
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  } 
+    
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
 );
 
-groupChatRouter.get('/:chatId/messages', verifyToken('accessToken'), getGroupChatMessages);
+groupChatRouter.get(
+  '/:chatId/messages',
+  verifyToken('accessToken'),
+  getGroupChatMessages
+  /* 
+  #swagger.summary = 'Retrieve messages from a specific group chat'
+
+  #swagger.description = 
+  'Retrieves messages from a group chat with advanced filtering capabilities. 
+  Features include pagination for efficient message loading, text-based search functionality, 
+  and customizable batch sizes. Messages are returned in descending chronological order, 
+  and only group members or the owner can access the chat history. 
+  The response includes message content, metadata, and pagination details for seamless navigation 
+  through the chat history.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'group chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.parameters['cursor'] = {
+    in: 'query',                            
+    description: 'Pagination cursor for fetching the next set of results',                   
+    required: false,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.parameters['search'] = {
+    in: 'query',                            
+    description: 'Search term to filter messages by content',                   
+    required: false,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.parameters['take'] = {
+    in: 'query',                            
+    description: 'Number of messages to retrieve per request',                   
+    required: false,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.responses[200] = {
+    description: 'Chat messages retrieved successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/GetGroupChatMessagesResponse'
+        },
+        examples: {
+          getMessagesResponse: {
+            $ref: "#/components/examples/GetGroupChatMessagesResponse"
+          }
+        }
+      }
+    }
+  }
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  } 
+    
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
+);
 
 groupChatRouter.patch(
   '/:chatId/add-members',
   verifyToken('accessToken'),
   validateRequest(addMembersToGroupChatSchema),
   addMembersToGroupChat
+  /* 
+  #swagger.summary = 'Add members to a specific group chat'
+
+  #swagger.description = 
+  'Enables group owners to add new members to an existing group chat. 
+  The endpoint validates friendship status, ensuring new members are friends with the owner. 
+  It handles duplicate member checks, preventing re-adding existing members, and supports adding 
+  multiple members simultaneously.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'group chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'application/json': {
+        schema:{
+          $ref: '#/components/schemas/AddMembersToGroupChatRequest'
+        }
+      }
+    }
+  } 
+
+  #swagger.responses[201] = {
+    description: 'Members added successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/AddMembersToGroupChatResponse'
+        },
+        examples: {
+          addMembersResponse: {
+            $ref: "#/components/examples/AddMembersToGroupChatResponse"
+          }
+        }
+      }
+    }
+  }
+
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }  
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  } 
+    
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
 );
 
 groupChatRouter.patch(
@@ -52,6 +450,114 @@ groupChatRouter.patch(
   verifyToken('accessToken'),
   validateRequest(removeMemberFromGroupChatSchema),
   removeMemberFromGroupChat
+  /* 
+  #swagger.summary = 'Remove a member from a specific group chat' 
+
+  #swagger.description = 
+  'Enables group owners to remove members from an existing group chat. 
+  The endpoint includes comprehensive validation checks: verifies member existence, 
+  prevents owner removal, confirms removal permissions, and ensures the target member is 
+  currently in the group. 
+  Only group owners have the authority to remove members, and the operation is irreversible.'
+
+  #swagger.parameters['chatId'] = {
+    in: 'path',                            
+    description: 'group chat ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'application/json': {
+        schema:{
+          $ref: '#/components/schemas/RemoveMemberFromGroupChatRequest'
+        }
+      }
+    }
+  } 
+
+  #swagger.responses[200] = {
+    description: 'Member deleted successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/RemoveMemberFromGroupChatResponse'
+        },
+        examples: {
+          deleteMemberResponse: {
+            $ref: "#/components/examples/RemoveMemberFromGroupChatResponse"
+          }
+        }
+      }
+    }
+  }
+
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }  
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  } 
+    
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  } 
+
+  #swagger.responses[409] = {
+    description: 'Conflict',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ConflictResponse"
+        },
+        examples: {
+          conflictResponse: {
+            $ref: "#/components/examples/ConflictResponse"
+          }
+        }
+      }           
+    }
+  }
+  */
 );
 
 export default groupChatRouter;


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the Group Chat APIs. It includes detailed Swagger annotations for all endpoints related to group messaging, covering chat creation, chat details retrieval, message retrieval, settings management, adding members and removing members. The documentation provides clear summaries, request/response schemas, and example payloads to facilitate easier integration and understanding of these critical communication features.