### PR TITLE
docs: sm-118 - add swagger docs for messaging apis

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -261,7 +261,81 @@ app.use(
 );
 
 // Message Routes
-app.use('/api/v1/messages', messagesRouter);
+app.use(
+  '/api/v1/messages',
+  messagesRouter
+  /* 
+  #swagger.tags = ['Messages']
+
+  #swagger.security = [{
+   "bearerAuth": []
+  }] 
+
+  #swagger.responses[401] = {
+    description: "Unauthorized Access",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/UnauthorizedAccessResponse"
+        },
+        examples: {
+          unauthorizedAccessResponse: {
+            $ref: "#/components/examples/UnauthorizedAccessResponse"
+          }
+        }
+      }           
+    }
+  }   
+
+  #swagger.responses[403] = {
+    description: 'Forbidden',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/ForbiddenResponse"
+        },
+        examples: {
+          forbiddenResponse: {
+            $ref: "#/components/examples/ForbiddenResponse"
+          }
+        }
+      }           
+    }
+  }
+
+  #swagger.responses[404] = {
+    description: 'Not found',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/NotFoundResponse"
+        },
+        examples: {
+          notFoundResponse: {
+            $ref: "#/components/examples/NotFoundResponse"
+          }
+        }
+      }           
+    }
+  }
+
+  #swagger.responses[500] = {
+    description: 'Internal server error',
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/InternalServerErrorResponse"
+        },
+        examples: {
+          internalServerErrorResponse: {
+            $ref: "#/components/examples/InternalServerErrorResponse"
+          }
+        }
+      }           
+    }
+  } 
+  */
+);
 
 app.use(errorConverter);
 app.use(errorHandler);

--- a/src/docs/index.ts
+++ b/src/docs/index.ts
@@ -2,6 +2,7 @@ import { authExamples, authSchemas } from './auth';
 import { errorExamples, errorSchemas } from './errors';
 import { friendRequestExamples, friendRequestsSchemas } from './friend-requests';
 import { groupChatExamples, groupChatSchemas } from './group-chats';
+import { messageExamples, messageSchemas } from './messages';
 import { oneOnOneChatExamples, oneOnOneChatSchemas } from './one-on-one-chats';
 import { userExamples, userSchemas } from './users';
 
@@ -10,6 +11,7 @@ const swaggerSchemas = {
   ...errorSchemas,
   ...friendRequestsSchemas,
   ...groupChatSchemas,
+  ...messageSchemas,
   ...oneOnOneChatSchemas,
   ...userSchemas
 };
@@ -18,6 +20,7 @@ const swaggerExamples = {
   ...errorExamples,
   ...friendRequestExamples,
   ...groupChatExamples,
+  ...messageExamples,
   ...oneOnOneChatExamples,
   ...userExamples
 };

--- a/src/docs/messages/examples.ts
+++ b/src/docs/messages/examples.ts
@@ -1,0 +1,21 @@
+export const messageExamples = {
+  SendMessageResponse: {
+    success: true,
+    message: 'Message sent successfully!',
+    data: {
+      id: '6718b6f1cme3bda15881a0gk',
+      content: 'Hello there!',
+      senderId: '66b33a2d19b3564668312345',
+      oneOnOneChatId: '66d6sh74e5cb752390d99gap',
+      groupChatId: null,
+      createdAt: '2024-10-23T08:42:25.605Z',
+      updatedAt: '2024-10-23T08:42:25.605Z',
+      isDeleted: false
+    }
+  },
+  DeleteMessageResponse: {
+    success: true,
+    message: 'Message deleted successfully!',
+    data: null
+  }
+};

--- a/src/docs/messages/index.ts
+++ b/src/docs/messages/index.ts
@@ -1,0 +1,2 @@
+export { messageExamples } from './examples';
+export { messageSchemas } from './schemas';

--- a/src/docs/messages/schemas.ts
+++ b/src/docs/messages/schemas.ts
@@ -1,0 +1,53 @@
+export const messageSchemas = {
+  SendMessageRequest: {
+    type: 'object',
+    properties: {
+      content: {
+        type: 'string',
+        example: ''
+      },
+      senderId: {
+        type: 'string',
+        example: ''
+      },
+      oneOnOneChatId: {
+        type: 'string',
+        example: ''
+      },
+      groupChatId: {
+        type: 'string',
+        example: ''
+      }
+    },
+    required: ['content', 'senderId'],
+    oneOf: [{ required: ['oneOnOneChatId'] }, { required: ['groupChatId'] }]
+  },
+  SendMessageResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          content: { type: 'string' },
+          senderId: { type: 'string' },
+          oneOnOneChatId: { type: 'string', nullable: true },
+          groupChatId: { type: 'string', nullable: true },
+          createdAt: { type: 'string', format: 'Date-Time' },
+          updatedAt: { type: 'string', format: 'Date-Time' },
+          isDeleted: { type: 'boolean' }
+        }
+      }
+    }
+  },
+  DeleteMessageResponse: {
+    type: 'object',
+    properties: {
+      success: { type: 'boolean' },
+      message: { type: 'string' },
+      data: { type: 'object', nullable: 'true' }
+    }
+  }
+};

--- a/src/routes/messages.routes.ts
+++ b/src/routes/messages.routes.ts
@@ -12,8 +12,96 @@ messagesRouter.post(
   validateRequest(sendMessageSchema),
   verifyToken('accessToken'),
   sendMessage
+  /*
+  #swagger.summary = 'Send message to a group/one-on-one chat'
+
+  #swagger.description = 'Enables users to send messages in either one-on-one or group chats. 
+  The endpoint validates sender authorization, chat existence, and membership status. 
+  It supports message creation in both chat types, updates the last message timestamp, and returns 
+  the created message details. 
+  The request body should contain only either a one-on-one chat ID or a group chat ID, not both.'
+
+  #swagger.requestBody = {
+    required: true,
+    content: {
+      'application/json': {
+        schema:{
+          $ref: '#/components/schemas/SendMessageRequest'
+        }
+      }
+    }
+  } 
+
+  #swagger.responses[201] = {
+    description: 'Message sent successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/SendMessageResponse'
+        },
+        examples: {
+          sendMessageResponse: {
+            $ref: "#/components/examples/SendMessageResponse"
+          }
+        }
+      }
+    }
+  }
+    
+  #swagger.responses[400] = {
+    description: "Bad request",
+    content: {
+      'application/json': {
+        schema:{
+          $ref: "#/components/schemas/BadRequestResponse"
+        },
+        examples: {
+          badRequestResponse: {
+            $ref: "#/components/examples/BadRequestResponse"
+          }
+        }
+      }           
+    }
+  }    
+  */
 );
 
-messagesRouter.patch('/delete/:messageId', verifyToken('accessToken'), deleteMessage);
+messagesRouter.patch(
+  '/delete/:messageId',
+  verifyToken('accessToken'),
+  deleteMessage
+  /*
+  #swagger.summary = 'Delete message from a group/one-on-one chat'
+
+  #swagger.description = 'Enables message deletion in both one-on-one and group chats using a 
+  soft delete approach. Message senders can delete their own messages, and in group chats, 
+  group owners have additional deletion privileges. The deletion process preserves message structure 
+  while removing content, maintaining chat history integrity. 
+  The endpoint includes comprehensive validation of message existence, chat context, and user permissions.'
+
+  #swagger.parameters['messageId'] = {
+    in: 'path',                            
+    description: 'message ID',                   
+    required: true,                     
+    type: 'string',                                                     
+  } 
+
+  #swagger.responses[200] = {
+    description: 'Message deleted successfully',
+    content: {
+      'application/json': {
+        schema: {
+          $ref: '#/components/schemas/DeleteMessageResponse'
+        },
+        examples: {
+          deleteMessageResponse: {
+            $ref: "#/components/examples/DeleteMessageResponse"
+          }
+        }
+      }
+    }
+  }
+  */
+);
 
 export default messagesRouter;


### PR DESCRIPTION
This pull request introduces comprehensive documentation for the Messaging APIs. It includes detailed Swagger annotations for endpoints related to messaging - sending messages and deleting messages. The documentation provides clear summaries, request/response schemas, and example payloads to facilitate easier integration and understanding of these features.